### PR TITLE
Fix CI: add haskell.nix binary cache to avoid building GHC from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The haskell.nix binary cache supplies the prebuilt GHC and dependency
+      # closure. Without it, CI compiles GHC from source, which is slow and
+      # exhausts the runner's disk ("No space left on device").
       - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            extra-substituters = https://cache.iog.io
+            extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
 


### PR DESCRIPTION
## Problem

CI on `master` has been failing. The `check` job ran for ~56 minutes and then died with:

```
binutils-2.44/bin/strip: ...ghc-9.10.3-inplace/.../ImpExp.o: No space left on device
Error when running Shake build system:
error: Cannot build '/nix/store/...-ghc-9.10.3.drv'.
```

### Root cause

This is a [haskell.nix](https://github.com/input-output-hk/haskell.nix) project (`compiler-nix-name = "ghc910"`). haskell.nix builds its own GHC, distributed via IOG's binary cache **`cache.iog.io`**. The CI nix config only had `cache.nixos.org`, so every run **compiled GHC 9.10.3 from source** — an hour-long build that exhausts the GitHub runner's disk.

I confirmed the prebuilt GHC closure is present in `cache.iog.io` (the exact `Deriver` matches the derivation CI was building from source):

```
$ curl -s https://cache.iog.io/iz2k3wvdwf4iwadp3rr2vpdz1wvypnym.narinfo
StorePath: /nix/store/iz2k3wvdwf4iwadp3rr2vpdz1wvypnym-ghc-9.10.3
Deriver: rwsgrwwn4gbpbimvl3jiwqaj39m359mq-ghc-9.10.3.drv   # <-- what CI built from source
Sig: hydra.iohk.io:...
```

The previous "successful" runs also built GHC from source (taking 1h+); the build was simply right at the disk limit and finally tipped over.

## Fix

Add the haskell.nix binary cache to the `nix-installer-action` via `extra-conf`, so the prebuilt GHC and its closure are fetched as binaries instead of compiled:

```yaml
extra-substituters = https://cache.iog.io
extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
```

This eliminates the disk-exhaustion failure and should cut CI time from ~1h to minutes. The `format`/`lint` checks are unaffected — they use `pkgs.haskellPackages.fourmolu`/`hlint` from `cache.nixos.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)